### PR TITLE
Disable lint:NewerVersionAvailable

### DIFF
--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -11,7 +11,10 @@
 	</issue>
 	<issue id="RtlHardcoded" severity="ignore" />
 	<issue id="GradleDependency" severity="ignore">
-		<!-- Keep the build stable -->
+		<!-- Keep the build stable, Renovate is taking care of keeping things up to date. -->
+	</issue>
+	<issue id="NewerVersionAvailable" severity="ignore">
+		<!-- Keep the build stable, Renovate is taking care of keeping things up to date. -->
 	</issue>
 	<issue id="SyntheticAccessor" severity="ignore">
 		<!-- Don't want to deal with it yet -->


### PR DESCRIPTION
This helps avoiding deadlocks in PRs: #263 and #264 happened together. There are 3 outdated libraries. PR 1 updates 2 of those, and PR 2 updates the 3rd. But because of lint, neither can be merged.