### PR TITLE
Replace com.gradle.enterprise with com.gradle.develocity

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,14 +39,14 @@ pluginManagement {
 		gradlePluginPortal {
 			content {
 				includeGroup("com.gradle")
-				includeGroup("com.gradle.enterprise")
+				includeGroup("com.gradle.develocity")
 			}
 		}
 	}
 }
 
 plugins {
-	id("com.gradle.enterprise") version "3.17"
+	id("com.gradle.develocity") version "3.17"
 	id("net.twisterrob.gradle.plugin.nagging")
 }
 
@@ -65,10 +65,10 @@ dependencyResolutionManagement {
 	}
 }
 
-gradleEnterprise {
+develocity {
 	buildScan {
-		termsOfServiceUrl = "https://gradle.com/terms-of-service"
-		termsOfServiceAgree = "yes"
+		termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
+		termsOfUseAgree = "yes"
 		if (isCI) {
 			fun setOutput(name: String, value: Any?) {
 				// Using `appendText` to make sure out outputs are not cleared.


### PR DESCRIPTION
```
w: file:///home/runner/work/net.twisterrob.colorfilters/net.twisterrob.colorfilters/settings.gradle.kts:68:1: 'gradleEnterprise((GradleEnterpriseExtension.() -> Unit)?): Unit' is deprecated. since 3.17

WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin:
- The deprecated "gradleEnterprise.buildScan.termsOfServiceUrl" API has been replaced by "develocity.buildScan.termsOfUseUrl"
- The deprecated "gradleEnterprise.buildScan.termsOfServiceAgree" API has been replaced by "develocity.buildScan.termsOfUseAgree"
- The deprecated "gradleEnterprise.buildScan.buildScanPublished" API has been replaced by "develocity.buildScan.buildScanPublished"
- The "com.gradle.enterprise" plugin has been replaced by "com.gradle.develocity"
```