### PR TITLE
Pre-fix Kotlin 2.0 deprecation errors

### DIFF
--- a/feature/base/src/main/kotlin/net/twisterrob/android/view/color/SwatchChooser.kt
+++ b/feature/base/src/main/kotlin/net/twisterrob/android/view/color/SwatchChooser.kt
@@ -1,11 +1,13 @@
 package net.twisterrob.android.view.color
 
+import android.annotation.TargetApi
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.ColorFilter
 import android.graphics.PixelFormat
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
+import android.os.Build
 import android.view.MotionEvent
 import android.view.View
 import net.twisterrob.android.view.color.swatches.PixelAbsoluteSwatch
@@ -142,6 +144,9 @@ class SwatchChooser(swatches: Collection<Swatch>) : Drawable(), View.OnTouchList
 		// Color filters are not supported, will always render custom draw.
 	}
 
+	// https://stackoverflow.com/a/78595315/253468
+	@Suppress("OVERRIDE_DEPRECATION") // Still used in API <29.
+	@TargetApi(Build.VERSION_CODES.Q) // This is a lie, but ObsoleteSdkInt will flag this method when minSdk goes above.
 	override fun getOpacity() = PixelFormat.UNKNOWN
 
 	override fun onTouch(v: View, event: MotionEvent): Boolean {

--- a/feature/base/src/main/kotlin/net/twisterrob/android/view/color/swatches/Swatch.kt
+++ b/feature/base/src/main/kotlin/net/twisterrob/android/view/color/swatches/Swatch.kt
@@ -1,9 +1,11 @@
 package net.twisterrob.android.view.color.swatches
 
+import android.annotation.TargetApi
 import android.graphics.Canvas
 import android.graphics.ColorFilter
 import android.graphics.PixelFormat
 import android.graphics.drawable.Drawable
+import android.os.Build
 import androidx.annotation.ColorInt
 import androidx.annotation.IntRange
 
@@ -35,6 +37,9 @@ abstract class Swatch : Drawable() {
 		// Default implementation, color filters are not supported, will mostly render custom draw.
 	}
 
+	// See https://stackoverflow.com/a/78595315/253468
+	@Suppress("OVERRIDE_DEPRECATION") // Still used in API <29.
+	@TargetApi(Build.VERSION_CODES.Q) // This is a lie, but ObsoleteSdkInt will flag this method when minSdk goes above.
 	override fun getOpacity(): Int = PixelFormat.UNKNOWN
 
 	open fun triggersColorChange(trackedArea: AreaCode): Boolean = true

--- a/feature/keyboard/src/main/kotlin/net/twisterrob/colorfilters/android/keyboard/BaseKeyboardHandler.kt
+++ b/feature/keyboard/src/main/kotlin/net/twisterrob/colorfilters/android/keyboard/BaseKeyboardHandler.kt
@@ -1,11 +1,7 @@
-@file:Suppress("DEPRECATION")
-
 package net.twisterrob.colorfilters.android.keyboard
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.inputmethodservice.KeyboardView
-import android.os.Build
 import android.text.Editable
 import android.text.InputType
 import android.util.Log
@@ -30,7 +26,8 @@ import net.twisterrob.colorfilters.android.keyboard.KeyboardHandler.CustomKeyboa
 // http://forum.xda-developers.com/showthread.php?t=2497237
 abstract class BaseKeyboardHandler(
 	protected val window: Window,
-	protected val keyboardView: KeyboardView
+	@Suppress("DEPRECATION")
+	protected val keyboardView: android.inputmethodservice.KeyboardView,
 ) : KeyboardHandler {
 
 	private val context: Context = keyboardView.context.applicationContext
@@ -46,6 +43,7 @@ abstract class BaseKeyboardHandler(
 	init {
 		hideCustomKeyboard()
 		window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
+		@Suppress("DEPRECATION")
 		keyboardView.isPreviewEnabled = false
 		hapticFeedback = true
 	}
@@ -92,7 +90,7 @@ abstract class BaseKeyboardHandler(
 	}
 
 	override fun handleBack(): Boolean {
-		if (keyboardView.handleBack()) {
+		if (@Suppress("DEPRECATION") keyboardView.handleBack()) {
 			return true
 		}
 		if (keyboardView.visibility == View.VISIBLE) {
@@ -137,7 +135,9 @@ abstract class BaseKeyboardHandler(
 		}
 	}
 
-	protected abstract inner class BaseOnKeyboardActionListener : KeyboardView.OnKeyboardActionListener {
+	@Suppress("OVERRIDE_DEPRECATION") // KeyboardView is deprecated, but the listener methods need to be used.
+	protected abstract inner class BaseOnKeyboardActionListener 
+		: @Suppress("DEPRECATION") android.inputmethodservice.KeyboardView.OnKeyboardActionListener {
 
 		private fun findView(): View? {
 			return window.currentFocus

--- a/feature/keyboard/src/main/kotlin/net/twisterrob/colorfilters/android/keyboard/FloatKeyboardHandler.kt
+++ b/feature/keyboard/src/main/kotlin/net/twisterrob/colorfilters/android/keyboard/FloatKeyboardHandler.kt
@@ -1,9 +1,5 @@
-@file:Suppress("DEPRECATION")
-
 package net.twisterrob.colorfilters.android.keyboard
 
-import android.inputmethodservice.Keyboard
-import android.inputmethodservice.KeyboardView
 import android.text.Editable
 import android.view.Window
 import android.widget.EditText
@@ -11,11 +7,15 @@ import net.twisterrob.colorfilters.android.keyboard.KeyCodes.KEY_CHANGE_SIGN
 import net.twisterrob.colorfilters.android.keyboard.KeyCodes.KEY_DECIMAL
 
 open class FloatKeyboardHandler(
-	window: Window, keyboardView: KeyboardView
+	window: Window,
+	@Suppress("DEPRECATION")
+	keyboardView: android.inputmethodservice.KeyboardView,
 ) : BaseKeyboardHandler(window, keyboardView) {
 
 	init {
-		keyboardView.keyboard = Keyboard(keyboardView.context, R.xml.keyboard_float)
+		@Suppress("DEPRECATION")
+		keyboardView.keyboard = android.inputmethodservice.Keyboard(keyboardView.context, R.xml.keyboard_float)
+		@Suppress("DEPRECATION")
 		keyboardView.setOnKeyboardActionListener(FloatKeyboardActionListener())
 	}
 

--- a/feature/keyboard/src/main/kotlin/net/twisterrob/colorfilters/android/keyboard/FloatKeyboardHandler.kt
+++ b/feature/keyboard/src/main/kotlin/net/twisterrob/colorfilters/android/keyboard/FloatKeyboardHandler.kt
@@ -23,7 +23,7 @@ open class FloatKeyboardHandler(
 
 		override fun onKey(editor: EditText, primaryCode: Int, keyCodes: IntArray): Boolean {
 			when (primaryCode) {
-				KEY_DECIMAL -> super.onKey('.'.toInt(), keyCodes)
+				KEY_DECIMAL -> super.onKey('.'.code, keyCodes)
 				KEY_CHANGE_SIGN -> editor.editableText?.negate()
 				else -> return false
 			}

--- a/feature/keyboard/src/main/kotlin/net/twisterrob/colorfilters/android/keyboard/KeyboardView.kt
+++ b/feature/keyboard/src/main/kotlin/net/twisterrob/colorfilters/android/keyboard/KeyboardView.kt
@@ -1,9 +1,6 @@
-@file:Suppress("DEPRECATION")
-
 package net.twisterrob.colorfilters.android.keyboard
 
 import android.content.Context
-import android.inputmethodservice.Keyboard
 import android.util.AttributeSet
 
 /**
@@ -17,17 +14,21 @@ import android.util.AttributeSet
  * ```
  * Defaults for backgrounds can't be set in code, because the fields have no accessors.
  */
-class KeyboardView : android.inputmethodservice.KeyboardView {
+@Suppress("OVERRIDE_DEPRECATION") // KeyboardView is deprecated, but the overridden methods need to be used.
+class KeyboardView : @Suppress("DEPRECATION") android.inputmethodservice.KeyboardView {
 
+	@Suppress("DEPRECATION")
 	constructor(context: Context, attrs: AttributeSet) :
 		super(context, attrs)
 
+	@Suppress("DEPRECATION")
 	constructor(context: Context, attrs: AttributeSet, defStyle: Int) :
 		super(context, attrs, defStyle)
 
 	/**
-	 * [Key.gap][Keyboard.Key.gap] is handled differently in [Key&#39;s constructor][Keyboard.Key.constructor]:
-	 * `gap` is before (to the left of) the key; whereas in [Keyboard.resize]:
+	 * [Key.gap][android.inputmethodservice.Keyboard.Key.gap] is handled differently
+	 * in [Key&#39;s constructor][android.inputmethodservice.Keyboard.Key.constructor]:
+	 * `gap` is before (to the left of) the key; whereas in [android.inputmethodservice.Keyboard.resize]:
 	 * `gap` is after (to the right of) the key.
 	 * `resize` is called from [onSizeChanged][android.inputmethodservice.KeyboardView.onSizeChanged].
 	 *
@@ -46,12 +47,14 @@ class KeyboardView : android.inputmethodservice.KeyboardView {
 	@Suppress("KDocUnresolvedReference")
 	private var keyboardChanged = false
 
-	override fun setKeyboard(keyboard: Keyboard) {
+	override fun setKeyboard(keyboard: @Suppress("DEPRECATION") android.inputmethodservice.Keyboard) {
+		@Suppress("DEPRECATION")
 		super.setKeyboard(keyboard)
 		keyboardChanged = true // force a resize call for this Keyboard
 	}
 
 	override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+		@Suppress("DEPRECATION")
 		super.onSizeChanged(w, h, oldw, oldh)
 		keyboardChanged = false // it was called, thank you.
 	}


### PR DESCRIPTION
 * Triggered by https://github.com/TWiStErRob/net.twisterrob.colorfilters/pull/326

Merging it before, because #326 is blocked.