### PR TITLE
Raise Android compileSdk from 36 to 37

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-android-compileSdk = "36"
+android-compileSdk = "37"
 android-minSdk = "21"
 android-targetSdk = "34"
 


### PR DESCRIPTION
Raises the shared Android compileSdk to 37. CI will validate compatibility.