### PR TITLE
Run instrumentation tests on Android API 35

### DIFF
--- a/.github/workflows/ci-instrumentation.yml
+++ b/.github/workflows/ci-instrumentation.yml
@@ -37,6 +37,6 @@ jobs:
           #- 21 # Doesn't work with JUnit 5!
           #- 23 # Doesn't work with JUnit 5!
           #- 26
-          - 29
+          - 35
           #- 32
           #- 33


### PR DESCRIPTION
JUnit 6 requires Android 15 (API 35) or newer for instrumentation tests. Move the CI emulator from API 29 to API 35.